### PR TITLE
Add ClawBench to evaluation benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,7 @@ We maintain a curated collection of papers exploring the path towards Foundation
 - MATH (dataset-math)
 - SVAMP (dataset-svamp)
 - MultiArith (dataset-multiarith)
+- ClawBench (Zhang et al., 2026) [[paper](https://arxiv.org/abs/2604.08523)] [[project](https://claw-bench.com/)] [[code](https://github.com/reacher-z/ClawBench)]
 
 ### Benchmark for MAS
 - Collab-Overcooked (Sun et al., 2025)


### PR DESCRIPTION
## Summary

- Add ClawBench under **Evaluation → Benchmark for Specific Tasks**.
- Include the [paper](https://arxiv.org/abs/2604.08523), [project site](https://claw-bench.com/), and [code](https://github.com/reacher-z/ClawBench) in the local list style.

ClawBench evaluates agents on everyday, live-site browser tasks, so the specific-task benchmark subsection is a closer fit than the neighboring multi-agent-system benchmark subsection.

## Validation

- Searched the full upstream branch for `ClawBench`, `2604.08523`, and `claw-bench.com`; no existing entry was found.
- Ran `git diff --check`.
- Verified all three links return HTTP 200.

Disclosure: I am a ClawBench maintainer.